### PR TITLE
Add blsb parameter

### DIFF
--- a/signals.json
+++ b/signals.json
@@ -41,6 +41,7 @@
                   "properties": {
                     "bix": { "type": "integer" },
                     "len": { "type": "integer" },
+                    "blsb": { "type": "boolean" },
                     "sign": { "type": "boolean" },
                     "min": { "type": "number" },
                     "max": { "type": "number" },


### PR DESCRIPTION
This parameter corresponds to "Bytes are in least-significant-byte order". E.g. if we have 2 bytes of data, ordered as [A, B], then a blsb signal will decode the bits in BA format rather than AB format. Note that the bits are still decoded in MSB format within each byte.