### PR TITLE
Add python signalset testing library.

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest tests/ --cov=src --cov-report=xml
+          pytest python/ --cov=python --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,10 +29,12 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest python/ --cov=python --cov-report=xml
+          pytest python/ --cov=python --cov-report=html
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      # Upload coverage report as artifact
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
-          file: ./coverage.xml
-          fail_ci_if_error: true
+          name: coverage-report
+          path: htmlcov/
+          retention-days: 14

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,38 @@
+name: Python Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+
+      - name: Run pytest
+        run: |
+          pytest tests/ --cov=src --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,13 +25,33 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install -r requirements.txt
 
       - name: Run pytest
         run: |
-          pytest python/ --cov=python --cov-report=html
+          pytest python/ --cov=python --cov-report=term --cov-report=html --cov-report=json
 
-      # Upload coverage report as artifact
+      - name: Post coverage comment
+        if: github.event_name == 'pull_request'
+        run: |
+          TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "Coverage: $TOTAL%" >> $GITHUB_STEP_SUMMARY
+
+          echo 'COVERAGE_COMMENT<<EOF' >> $GITHUB_ENV
+          echo '## Coverage Report' >> $GITHUB_ENV
+          echo '📊 Total coverage: '"$TOTAL"'%' >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          coverage report >> $GITHUB_ENV
+          echo '```' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: ${{ env.COVERAGE_COMMENT }}
+          comment_tag: coverage
+
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/python/can_frame.py
+++ b/python/can_frame.py
@@ -1,0 +1,280 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Dict, List, Optional, Set, Tuple, Iterator, Any
+import re
+
+class CANFramePart(Enum):
+    """Identifies different segments of a CAN frame for error reporting."""
+    IDENTIFIER = auto()
+    EXTENDED_RECEIVE_ADDRESS = auto()
+    TYPE = auto()
+    SIZE = auto()
+    INDEX = auto()
+    DATA = auto()
+
+class CANFrameError(Exception):
+    """
+    Raised when parsing CAN frames fails. Includes details about which part
+    of the frame caused the error to aid in debugging.
+    """
+    def __init__(self, message: str, source: str = "", part: Optional[CANFramePart] = None):
+        self.message = message
+        self.source = source  # Original problematic frame data
+        self.part = part      # Which part of the frame had issues
+        super().__init__(self.message)
+
+class CANIDFormat(Enum):
+    """
+    CAN ID formats used in automotive networks:
+    ELEVEN_BIT: Standard format (11-bit identifier)
+    TWENTY_NINE_BIT: Extended format (29-bit identifier)
+    """
+    ELEVEN_BIT = auto()
+    TWENTY_NINE_BIT = auto()
+
+class DataFrameType(Enum):
+    """
+    ISO-TP frame types used for segmented message transfer:
+    SINGLE_FRAME: Complete message in one frame
+    FIRST_FRAME: Initial frame of multi-frame message
+    CONSECUTIVE_FRAME: Continuation frame in multi-frame message
+    FLOW_CONTROL_FRAME: Flow control management
+    """
+    SINGLE_FRAME = 0x00
+    FIRST_FRAME = 0x01
+    CONSECUTIVE_FRAME = 0x02
+    FLOW_CONTROL_FRAME = 0x03
+
+    @classmethod
+    def from_byte(cls, byte: int) -> 'DataFrameType':
+        """Converts raw frame type byte to enum, handling invalid types."""
+        try:
+            return cls(byte)
+        except ValueError:
+            raise CANFrameError(f"Invalid data frame type: {byte:02X}")
+
+@dataclass
+class DataFrameHeader:
+    """
+    ISO-TP frame header information. Contains either:
+    - Message size (for SINGLE/FIRST frames)
+    - Frame sequence number (for CONSECUTIVE frames)
+    """
+    class Type(Enum):
+        SINGLE = auto()      # Complete message
+        FIRST = auto()       # Start of segmented message
+        CONSECUTIVE = auto() # Continuation of segmented message
+        FLOW = auto()        # Flow control
+
+    type: Type
+    value: Optional[int] = None  # Size or sequence number
+
+@dataclass
+class CANFrame:
+    """Represents a single CAN frame with ISO-TP transport layer information."""
+    can_id_format: CANIDFormat
+    can_identifier: str
+    extended_receive_address: Optional[str]
+    data_frame_type: DataFrameType
+    data_frame_header: DataFrameHeader
+    data: bytes
+
+    @staticmethod
+    def parse_can_identifier(line: str, can_id_format: CANIDFormat) -> Tuple[str, int]:
+        """
+        Extracts CAN identifier from raw frame data.
+        Returns tuple of (identifier, index after identifier).
+
+        11-bit IDs use 3 hex chars, 29-bit use 8 hex chars.
+        """
+        if can_id_format == CANIDFormat.ELEVEN_BIT:
+            if len(line) < 3:
+                raise CANFrameError("Malformed CAN identifier", line, CANFramePart.IDENTIFIER)
+            return line[:3], 3
+        elif can_id_format == CANIDFormat.TWENTY_NINE_BIT:
+            if len(line) < 8:
+                raise CANFrameError("Malformed CAN identifier", line, CANFramePart.IDENTIFIER)
+            return line[:8], 8
+
+    @classmethod
+    def from_line(cls, line: str, can_id_format: CANIDFormat, extended_addressing_enabled: bool = False) -> 'CANFrame':
+        """
+        Parses a single line of CAN frame data. Handles:
+        - Standard and extended CAN IDs
+        - ISO-TP segmentation
+        - Optional extended addressing
+        """
+        # Remove any whitespace
+        line = re.sub(r'\s+', '', line)
+
+        # Parse CAN identifier
+        can_identifier, index = cls.parse_can_identifier(line, can_id_format)
+
+        # Parse extended addressing or type
+        extended_receive_address = None
+
+        if extended_addressing_enabled is True:
+            if len(line) < index + 2:
+                raise CANFrameError("Malformed extended receive address", line, CANFramePart.EXTENDED_RECEIVE_ADDRESS)
+            extended_receive_address = line[index:index + 2]
+            index += 2
+
+        # Parse type
+        if len(line) < index + 1:
+            raise CANFrameError("Malformed type", line, CANFramePart.TYPE)
+        try:
+            byte = int(line[index], 16)
+            data_frame_type = DataFrameType.from_byte(byte)
+            index += 1
+        except ValueError:
+            raise CANFrameError(f"Invalid character: {line[index]}")
+
+        # Parse frame header based on type
+        data_frame_header = None
+        if data_frame_type == DataFrameType.SINGLE_FRAME:
+            if len(line) < index + 1:
+                raise CANFrameError("Malformed size", line, CANFramePart.SIZE)
+            try:
+                size = int(line[index], 16)
+                data_frame_header = DataFrameHeader(DataFrameHeader.Type.SINGLE, size)
+                index += 1
+            except ValueError:
+                raise CANFrameError("Invalid size")
+
+        elif data_frame_type == DataFrameType.FIRST_FRAME:
+            if len(line) < index + 3:
+                raise CANFrameError("Malformed size", line, CANFramePart.SIZE)
+            try:
+                size = int(line[index:index + 3], 16)
+                data_frame_header = DataFrameHeader(DataFrameHeader.Type.FIRST, size)
+                index += 3
+            except ValueError:
+                raise CANFrameError("Invalid size")
+
+        elif data_frame_type == DataFrameType.CONSECUTIVE_FRAME:
+            if len(line) < index + 1:
+                raise CANFrameError("Malformed index", line, CANFramePart.INDEX)
+            try:
+                frame_index = int(line[index], 16)
+                data_frame_header = DataFrameHeader(DataFrameHeader.Type.CONSECUTIVE, frame_index)
+                index += 1
+            except ValueError:
+                raise CANFrameError("Invalid frame index")
+
+        elif data_frame_type == DataFrameType.FLOW_CONTROL_FRAME:
+            data_frame_header = DataFrameHeader(DataFrameHeader.Type.FLOW)
+
+        # Parse remaining data
+        if len(line) <= index:
+            raise CANFrameError("Malformed data", line, CANFramePart.DATA)
+        data_string = line[index:]
+        if len(data_string) % 2 != 0:
+            raise CANFrameError("Malformed data (odd length)", line, CANFramePart.DATA)
+        try:
+            data = bytes.fromhex(data_string)
+        except ValueError:
+            raise CANFrameError("Invalid hex data", line, CANFramePart.DATA)
+
+        return cls(
+            can_id_format=can_id_format,
+            can_identifier=can_identifier,
+            extended_receive_address=extended_receive_address,
+            data_frame_type=data_frame_type,
+            data_frame_header=data_frame_header,
+            data=data
+        )
+
+@dataclass
+class CANPacket:
+    """
+    Complete ISO-TP message reassembled from one or more CAN frames.
+    Contains the original CAN ID and complete payload data.
+    """
+    can_identifier: str
+    extended_receive_address: Optional[str]
+    data: bytes
+
+class CANFrameScanner:
+    """
+    Processes CAN frames and reassembles them into complete ISO-TP packets.
+    Handles multi-frame messages by maintaining partial packet state.
+    """
+    def __init__(self, frames: List[CANFrame]):
+        self.frames = frames
+        self._partial_packets: Dict[str, Tuple[bytes, int]] = {}  # CAN ID -> (accumulated data, total size)
+        self._frame_index = 0
+
+    @classmethod
+    def from_ascii_string(cls, ascii_string: str,
+                         can_id_format: CANIDFormat = CANIDFormat.ELEVEN_BIT,
+                         extended_addressing_enabled: Optional[bool] = None) -> Optional['CANFrameScanner']:
+        """
+        Creates a scanner from ASCII hex dump of CAN frames.
+        Handles both single-line and multi-line inputs.
+        """
+        lines = cls._format_ascii_string(ascii_string)
+        if not lines:
+            return None
+
+        frames = []
+        for line in lines:
+            try:
+                frame = CANFrame.from_line(line, can_id_format, extended_addressing_enabled)
+                frames.append(frame)
+            except CANFrameError as e:
+                print(f"Error parsing frame: {e}")
+                continue
+
+        return cls(frames)
+
+    @staticmethod
+    def _format_ascii_string(ascii_string: str) -> Optional[List[str]]:
+        """Splits and cleans up raw ASCII input into frame strings."""
+        return [line.strip() for line in ascii_string.split('\n')]
+
+    def __iter__(self) -> Iterator[CANPacket]:
+        return self
+
+    def __next__(self) -> CANPacket:
+        """
+        Processes frames sequentially, yielding complete packets.
+        Maintains state for multi-frame messages until they're complete.
+        """
+        while self._frame_index < len(self.frames):
+            frame = self.frames[self._frame_index]
+            self._frame_index += 1
+
+            can_id = frame.can_identifier
+
+            if frame.data_frame_header.type == DataFrameHeader.Type.SINGLE:
+                return CANPacket(
+                    can_identifier=can_id,
+                    extended_receive_address=frame.extended_receive_address,
+                    data=frame.data
+                )
+
+            elif frame.data_frame_header.type == DataFrameHeader.Type.FIRST:
+                self._partial_packets[can_id] = (frame.data, frame.data_frame_header.value)
+
+            elif frame.data_frame_header.type == DataFrameHeader.Type.CONSECUTIVE:
+                if can_id not in self._partial_packets:
+                    continue
+
+                accumulator, packet_size = self._partial_packets[can_id]
+                accumulator += frame.data
+
+                if len(accumulator) >= packet_size:
+                    data = accumulator[:packet_size]
+                    del self._partial_packets[can_id]
+                    return CANPacket(
+                        can_identifier=can_id,
+                        extended_receive_address=frame.extended_receive_address,
+                        data=data
+                    )
+                else:
+                    self._partial_packets[can_id] = (accumulator, packet_size)
+
+            elif frame.data_frame_header.type == DataFrameHeader.Type.FLOW:
+                continue  # Flow control frames not needed for reassembly
+
+        raise StopIteration

--- a/python/command_registry.py
+++ b/python/command_registry.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Any, Tuple
+from enum import Enum
+
+from can_frame import CANFrame, CANPacket, CANFrameScanner, CANIDFormat
+from signals import Command, Scaling
+
+class ServiceType(Enum):
+    SERVICE_21 = 0x21
+    SERVICE_22 = 0x22
+
+@dataclass
+class CommandResponse:
+    command: 'Command'
+    data: bytes
+    values: Dict[str, Any]
+
+class CommandRegistry:
+    def __init__(self, commands: List['Command']):
+        # Group commands by parameter for efficient lookup
+        self.commands_by_parameter = {}
+        for cmd in commands:
+            # Cast cmd.parameter.type.value from a hex string to an integer
+            service_id = int(cmd.parameter.type.value, 16)
+            param_key = (service_id, cmd.parameter.value)
+            if param_key not in self.commands_by_parameter:
+                self.commands_by_parameter[param_key] = []
+            self.commands_by_parameter[param_key].append(cmd)
+
+    def identify_commands(self, packet: 'CANPacket') -> List[CommandResponse]:
+        """Identify and parse commands from a CAN packet."""
+        data = packet.data
+        if not data:
+            return []
+
+        # First byte should be service response (service ID + 0x40)
+        service_response = data[0]
+        if service_response < 0x40:
+            return []
+
+        service = service_response - 0x40
+        data = data[1:]  # Remove service byte
+
+        if service == ServiceType.SERVICE_21.value:
+            return self._extract_service_21_commands(packet.can_identifier, data)
+        elif service == ServiceType.SERVICE_22.value:
+            return self._extract_service_22_commands(packet.can_identifier, data)
+        return []
+
+    def _extract_service_22_commands(self, can_id: str, data: bytes) -> List[CommandResponse]:
+        responses = []
+        while data:
+            if len(data) < 2:
+                break
+
+            # Service 22 uses 2-byte PIDs
+            pid = (data[0] << 8) | data[1]
+            data = data[2:]  # Remove PID bytes
+
+            param_key = (ServiceType.SERVICE_22.value, pid)
+            commands = self.commands_by_parameter.get(param_key, [])
+
+            command = next(
+                (cmd for cmd in commands
+                 if cmd.receive_address is None or
+                 f"{cmd.receive_address:03X}" == can_id),
+                None
+            )
+
+            if command:
+                values = {}
+                remaining_data = data
+                for signal in command.signals:
+                    if isinstance(signal.format, Scaling):
+                        try:
+                            value = signal.format.decode_value(remaining_data)
+                            values[signal.id] = value
+                        except Exception as e:
+                            print(f"Error decoding signal {signal.id}: {e}")
+
+                responses.append(CommandResponse(command, remaining_data, values))
+
+            # Move to next parameter's data
+            data = data[4:]  # Typical data length for service 22
+
+        return responses
+
+    def _extract_service_21_commands(self, can_id: str, data: bytes) -> List[CommandResponse]:
+        responses = []
+        while data:
+            if len(data) < 1:
+                break
+
+            offset = data[0]
+            data = data[1:]  # Remove offset byte
+
+            param_key = (ServiceType.SERVICE_21.value, offset)
+            commands = self.commands_by_parameter.get(param_key, [])
+
+            command = next(
+                (cmd for cmd in commands
+                 if cmd.receive_address is None or
+                 f"{cmd.receive_address:03X}" == can_id),
+                None
+            )
+
+            if command:
+                values = {}
+                remaining_data = data
+                for signal in command.signals:
+                    if isinstance(signal.format, Scaling):
+                        try:
+                            value = signal.format.decode_value(remaining_data)
+                            values[signal.id] = value
+                        except Exception as e:
+                            print(f"Error decoding signal {signal.id}: {e}")
+
+                responses.append(CommandResponse(command, remaining_data, values))
+
+            # Move to next parameter's data
+            data = data[2:]  # Typical data length for service 21
+
+        return responses
+
+def decode_obd_response(
+        signalset: 'SignalSet',
+        response_hex: str,
+        can_id_format: CANIDFormat = CANIDFormat.ELEVEN_BIT,
+        extended_addressing_enabled: Optional[bool] = None
+        ) -> Dict[str, Any]:
+    """Decode an OBD response using a signal set definition.
+
+    Args:
+        signalset: SignalSet instance containing signal definitions
+        response_hex: Hex string of the OBD response
+
+    Returns:
+        Dictionary mapping signal IDs to their decoded values
+    """
+    # Create command registry
+    registry = CommandRegistry(list(signalset.commands))
+
+    # Parse CAN frames from response
+    scanner = CANFrameScanner.from_ascii_string(
+        response_hex,
+        can_id_format=can_id_format,
+        extended_addressing_enabled=extended_addressing_enabled
+    )
+    if not scanner:
+        raise ValueError(f"Could not parse response: {response_hex}")
+
+    # Process each CAN packet
+    results = {}
+    for packet in scanner:
+        # Identify and decode commands
+        command_responses = registry.identify_commands(packet)
+
+        # Collect all decoded signal values
+        for response in command_responses:
+            results.update(response.values)
+
+    return results

--- a/python/signals.py
+++ b/python/signals.py
@@ -1,0 +1,238 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Set, Union, Tuple
+import json
+import math
+
+class ParameterType(Enum):
+    SERVICE_21 = "21"
+    SERVICE_22 = "22"
+
+@dataclass(frozen=True)
+class Parameter:
+    type: ParameterType
+    value: Union[int, str]
+
+    @staticmethod
+    def from_json(data: Dict) -> 'Parameter':
+        for param_type in [ParameterType.SERVICE_21, ParameterType.SERVICE_22]:
+            if param_type.value in data:
+                # Handle both string and integer representations
+                value = data[param_type.value]
+                if isinstance(value, str):
+                    value = int(value, 16)
+                return Parameter(param_type, value)
+        raise ValueError(f"Invalid parameter format: {data}")
+
+    def as_message(self) -> str:
+        if self.type == ParameterType.SERVICE_22:
+            return f"{self.type.value}{self.value:04X}"
+        else:
+            return f"{self.type.value}{self.value:02X}"
+
+class UnitCategory(Enum):
+    TEMPERATURE = "temperature"
+    LENGTH = "length"
+    SPEED = "speed"
+    REVOLUTIONS = "revolutions"
+    DURATION = "duration"
+    CURRENT = "current"
+    CHARGE = "charge"
+    VOLTAGE = "voltage"
+    ENERGY = "energy"
+    TORQUE = "torque"
+    SCALAR = "scalar"
+    PERCENT = "percent"
+    NORMALIZED = "normalized"
+    ENCODING = "encoding"
+    BOOLEAN = "boolean"
+    ANGLE = "angle"
+    POWER = "power"
+    PRESSURE = "pressure"
+    VOLUME = "volume"
+    MASS_FLOW = "massFlow"
+    ACCELERATION = "acceleration"
+    UNKNOWN = "unknown"
+
+@dataclass(frozen=True)
+class Scaling:
+    bit_length: int
+    max_value: float
+    unit: str
+    bit_offset: int = 0
+    bytes_lsb: bool = False
+    signed: bool = False
+    min_value: float = 0
+    offset: float = 0
+    scalar: float = 1
+    divisor: float = 1
+    null_min: Optional[float] = None
+    null_max: Optional[float] = None
+    optimal_min: Optional[float] = None
+    optimal_max: Optional[float] = None
+    optimal_value: Optional[float] = None
+
+    @staticmethod
+    def from_json(data: Dict) -> 'Scaling':
+        return Scaling(
+            bit_offset=data.get('bix', 0),
+            bit_length=data['len'],
+            bytes_lsb=data.get('blsb', False),
+            signed=data.get('sign', False),
+            min_value=data.get('min', 0),
+            max_value=data['max'],
+            offset=data.get('add', 0),
+            scalar=data.get('mul', 1),
+            divisor=data.get('div', 1),
+            unit=data['unit'],
+            null_min=data.get('nullmin'),
+            null_max=data.get('nullmax'),
+            optimal_min=data.get('omin'),
+            optimal_max=data.get('omax'),
+            optimal_value=data.get('oval')
+        )
+
+    def decode_value(self, data: bytes) -> float:
+        """Decode a value from bytes using the scaling parameters."""
+        raw_value = self._extract_bits(data)
+        if self.signed:
+            raw_value = self._twos_complement(raw_value, self.bit_length)
+
+        value = (raw_value * self.scalar / self.divisor) + self.offset
+
+        if self.max_value > self.min_value:
+            value = max(self.min_value, min(value, self.max_value))
+
+        return value
+
+    def _extract_bits(self, data: bytes) -> int:
+        """Extract bits from byte data according to offset and length."""
+        total_bits = len(data) * 8
+        start_bit = self.bit_offset
+        end_bit = start_bit + self.bit_length
+
+        if end_bit > total_bits:
+            raise ValueError(f"Not enough data: need {end_bit} bits, have {total_bits}")
+
+        if self.bytes_lsb and self.bit_length > 8:
+            # Reverse bytes for LSB format
+            data = bytes(reversed(data))
+
+        result = 0
+        for i in range(start_bit, end_bit):
+            byte_idx = i // 8
+            bit_idx = 7 - (i % 8)  # MSB format
+            if (data[byte_idx] & (1 << bit_idx)) != 0:
+                result |= 1 << (end_bit - i - 1)
+
+        return result
+
+    def _twos_complement(self, value: int, bits: int) -> int:
+        """Convert two's complement value to signed integer."""
+        if value & (1 << (bits - 1)):
+            value -= 1 << bits
+        return value
+
+@dataclass(frozen=True)
+class EnumerationValue:
+    value: str
+    description: str
+
+@dataclass(frozen=True)
+class Enumeration:
+    bit_length: int
+    map: Dict[int, EnumerationValue]
+    bit_offset: int = 0
+
+    @staticmethod
+    def from_json(data: Dict) -> 'Enumeration':
+        value_map = {
+            k: EnumerationValue(**v) if isinstance(v, dict) else EnumerationValue(str(v), str(v))
+            for k, v in data['map'].items()
+        }
+        return Enumeration(
+            bit_offset=data.get('bix', 0),
+            bit_length=data['len'],
+            map=value_map
+        )
+
+@dataclass(frozen=True)
+class Signal:
+    id: str
+    name: str
+    description: Optional[str]
+    format: Union[Scaling, Enumeration]
+    path: Optional[str] = None
+    hidden: bool = False
+    suggested_metric: Optional[str] = None
+
+    @staticmethod
+    def from_json(data: Dict) -> 'Signal':
+        fmt = data['fmt']
+        if 'map' in fmt:
+            format_obj = Enumeration.from_json(fmt)
+        else:
+            format_obj = Scaling.from_json(fmt)
+
+        return Signal(
+            id=data['id'],
+            name=data['name'],
+            description=data.get('description'),
+            format=format_obj,
+            path=data.get('path'),
+            hidden=data.get('hidden', False),
+            suggested_metric=data.get('suggestedMetric')
+        )
+
+@dataclass(frozen=True)
+class Command:
+    parameter: Parameter
+    header: int
+    receive_address: Optional[int]
+    signals: Tuple[Signal, ...]  # Using tuple instead of set for hashability
+    update_frequency: float
+    extended_address: Optional[int] = None
+    tester_address: Optional[int] = None
+    timeout: Optional[int] = None
+    force_flow_control: bool = False
+    debug: bool = False
+
+    @staticmethod
+    def from_json(data: Dict) -> 'Command':
+        header = int(data['hdr'], 16)
+        receive_address = int(data['rax'], 16) if 'rax' in data else None
+        signals = tuple(sorted(
+            (Signal.from_json(s) for s in data['signals']),
+            key=lambda x: x.id
+        ))
+
+        return Command(
+            parameter=Parameter.from_json(data['cmd']),
+            header=header,
+            receive_address=receive_address,
+            signals=signals,
+            update_frequency=data['freq'],
+            extended_address=int(data['eax'], 16) if 'eax' in data else None,
+            tester_address=int(data['tst'], 16) if 'tst' in data else None,
+            timeout=int(data['tmo'], 16) if 'tmo' in data else None,
+            force_flow_control=data.get('fcm1', False),
+            debug=data.get('dbg', False)
+        )
+
+@dataclass
+class SignalSet:
+    commands: Set[Command]
+    diagnostic_level: Optional[int] = None
+    signal_groups: Optional[Set] = None
+
+    @classmethod
+    def from_json(cls, json_data: str) -> 'SignalSet':
+        data = json.loads(json_data)
+        commands = {Command.from_json(cmd) for cmd in data['commands']}
+        diagnostic_level = int(data['diagnosticLevel'], 16) if 'diagnosticLevel' in data else None
+
+        return cls(
+            commands=commands,
+            diagnostic_level=diagnostic_level,
+            signal_groups=None  # TODO: Implement signal groups if needed
+        )

--- a/python/signals_testing.py
+++ b/python/signals_testing.py
@@ -1,0 +1,34 @@
+import pytest
+from typing import Dict, Any, Optional
+from can_frame import CANIDFormat
+from command_registry import decode_obd_response
+from signals import SignalSet, Command, Signal, Scaling
+
+def obd_testrunner(
+        signalset_json: str,
+        response_hex: str,
+        expected_values: Dict[str, float],
+        can_id_format: CANIDFormat = CANIDFormat.ELEVEN_BIT,
+        extended_addressing_enabled: Optional[bool] = None
+    ):
+    """Test decoding an OBD response against expected values.
+
+    Args:
+        signalset_json: JSON string containing the signal set definition
+        response_hex: Hex string of the OBD response
+        expected_values: Dictionary mapping signal IDs to their expected values
+    """
+    signalset = SignalSet.from_json(signalset_json)
+    actual_values = decode_obd_response(
+        signalset,
+        response_hex,
+        can_id_format=can_id_format,
+        extended_addressing_enabled=extended_addressing_enabled
+    )
+
+    # Test each expected signal value
+    for signal_id, expected_value in expected_values.items():
+        assert signal_id in actual_values, f"Signal {signal_id} not found in decoded response"
+        actual_value = actual_values[signal_id]
+        assert pytest.approx(actual_value) == expected_value, \
+            f"Signal {signal_id} value mismatch: got {actual_value}, expected {expected_value}"

--- a/python/test_can_frame.py
+++ b/python/test_can_frame.py
@@ -1,0 +1,105 @@
+import pytest
+from can_frame import (
+    CANFrame, CANFrameScanner, CANIDFormat, CANFrameError,
+    DataFrameType, DataFrameHeader
+)
+
+def test_single_frame():
+    """Test parsing a single frame response."""
+    response = "7E803410D00"  # Standard single frame response
+    scanner = CANFrameScanner.from_ascii_string(
+        response,
+        can_id_format=CANIDFormat.ELEVEN_BIT
+    )
+
+    assert scanner is not None
+    packet = next(scanner)
+    assert packet.can_identifier == "7E8"
+    assert packet.extended_receive_address is None
+    assert packet.data == bytes.fromhex("410D00")
+
+def test_multi_frame():
+    """Test parsing a multi-frame response."""
+    response = """
+    7E81014490201534231
+    7E8215A53334A453630
+    7E82245323832313032
+    """
+    scanner = CANFrameScanner.from_ascii_string(
+        response,
+        can_id_format=CANIDFormat.ELEVEN_BIT
+    )
+
+    assert scanner is not None
+    packet = next(scanner)
+    assert packet.can_identifier == "7E8"
+    assert len(packet.data) == 20
+    assert packet.data == bytes.fromhex("4902015342315A53334A45363045323832313032")
+
+def test_extended_addressing():
+    """Test parsing responses with extended addressing."""
+    response = "7E8F103410D00"
+    scanner = CANFrameScanner.from_ascii_string(
+        response,
+        can_id_format=CANIDFormat.ELEVEN_BIT,
+        extended_addressing_enabled=True
+    )
+
+    assert scanner is not None
+    packet = next(scanner)
+    assert packet.can_identifier == "7E8"
+    assert packet.extended_receive_address == "F1"
+    assert packet.data == bytes.fromhex("410D00")
+
+def test_malformed_frames():
+    """Test handling of malformed frame data."""
+    # Test invalid CAN identifier
+    with pytest.raises(CANFrameError):
+        CANFrame.from_line(
+            "ZZZ064B000000000",  # Invalid hex
+            can_id_format=CANIDFormat.ELEVEN_BIT
+        )
+
+    # Test truncated frame
+    with pytest.raises(CANFrameError):
+        CANFrame.from_line(
+            "7E8",  # Too short
+            can_id_format=CANIDFormat.ELEVEN_BIT
+        )
+
+    # Test invalid frame type
+    with pytest.raises(CANFrameError):
+        CANFrame.from_line(
+            "7E8F64B000000000",  # Invalid frame type (F)
+            can_id_format=CANIDFormat.ELEVEN_BIT
+        )
+
+def test_can_id_formats():
+    """Test different CAN ID format handling."""
+    # Test 11-bit format with extended addressing
+    frame = CANFrame.from_line(
+        "7E8F103410D00",
+        can_id_format=CANIDFormat.ELEVEN_BIT,
+        extended_addressing_enabled=True
+    )
+    assert frame.can_identifier == "7E8"
+
+    # Test 29-bit format.
+    frame = CANFrame.from_line(
+        """
+        18DAF126103B6260010000FF
+        18DAF1262100F000000000D9
+        18DAF1262200E800DA00E300
+        18DAF1262300000000000000
+        18DAF126241720161A000000
+        18DAF1262500000000000000
+        18DAF1262600000000000000
+        18DAF1262700000000000000
+        18DAF1262800000000555555
+        """,
+        can_id_format=CANIDFormat.TWENTY_NINE_BIT
+    )
+    assert frame.can_identifier == "18DAF126"
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/python/test_command_registry.py
+++ b/python/test_command_registry.py
@@ -1,0 +1,176 @@
+import pytest
+from typing import Dict, Any, List
+import json
+
+from command_registry import CommandRegistry, CommandResponse, ServiceType
+from signals import SignalSet, Command, Signal, Scaling, Parameter, ParameterType
+from can_frame import CANPacket
+
+def create_test_command(
+    pid: int,
+    service_type: ServiceType,
+    receive_address: str,
+    signals: List[Signal]
+) -> Command:
+    """Helper to create a test command with specified parameters."""
+    return Command(
+        parameter=Parameter(
+            type=ParameterType(service_type.name.replace('SERVICE_', '')),
+            value=pid
+        ),
+        header=0x7E0,
+        receive_address=int(receive_address, 16) if receive_address else None,
+        signals=tuple(signals),
+        update_frequency=1.0
+    )
+
+def create_test_signal(
+    signal_id: str,
+    name: str,
+    scaling_params: Dict[str, Any]
+) -> Signal:
+    """Helper to create a test signal with specified scaling parameters."""
+    return Signal(
+        id=signal_id,
+        name=name,
+        description=None,
+        format=Scaling(**scaling_params)
+    )
+
+def test_identify_service_22_command():
+    """Test identifying and decoding a Service 22 command response."""
+    # Create test signal for battery voltage
+    voltage_signal = create_test_signal(
+        "F150_ODO",
+        "Odometer (Instrument panel)",
+        {
+            "bit_length": 24,
+            "max_value": 1677721,
+            "divisor": 10,
+            "unit": "kilometers"
+        }
+    )
+
+    # Create test command
+    command = create_test_command(
+        pid=0x404C,
+        service_type=ServiceType.SERVICE_22,
+        receive_address="728",
+        signals=[voltage_signal]
+    )
+
+    registry = CommandRegistry([command])
+
+    packet = CANPacket(
+        can_identifier="728",
+        extended_receive_address=None,
+        data=bytes.fromhex("62404C23CE1C")
+    )
+
+    responses = registry.identify_commands(packet)
+
+    assert len(responses) == 1
+    response = responses[0]
+    assert response.command == command
+    assert "F150_ODO" in response.values
+    assert pytest.approx(response.values["F150_ODO"]) == 234652.4
+
+def test_multiple_signals_in_command():
+    """Test decoding multiple signals from a single command response."""
+    # Create test signals for tire pressures
+    signals = [
+        create_test_signal(
+            f"TIRE_PRESSURE_{pos}",
+            f"Tire Pressure {pos}",
+            {
+                "bit_offset": i * 8,
+                "bit_length": 8,
+                "max_value": 255,
+                "unit": "psi",
+                "divisor": 4
+            }
+        )
+        for i, pos in enumerate(["FL", "FR", "RL", "RR"])
+    ]
+
+    command = create_test_command(
+        pid=0x2160,
+        service_type=ServiceType.SERVICE_22,
+        receive_address="7E8",
+        signals=signals
+    )
+
+    registry = CommandRegistry([command])
+
+    # Response with 4 tire pressures: 32, 33, 31, 32 PSI
+    packet = CANPacket(
+        can_identifier="7E8",
+        extended_receive_address=None,
+        data=bytes.fromhex("622160" + "80847C80")
+    )
+
+    responses = registry.identify_commands(packet)
+
+    assert len(responses) == 1
+    response = responses[0]
+    assert response.command == command
+
+    expected_pressures = {
+        "TIRE_PRESSURE_FL": 32.0,
+        "TIRE_PRESSURE_FR": 33.0,
+        "TIRE_PRESSURE_RL": 31.0,
+        "TIRE_PRESSURE_RR": 32.0
+    }
+
+    for signal_id, expected_value in expected_pressures.items():
+        assert signal_id in response.values
+        assert pytest.approx(response.values[signal_id]) == expected_value
+
+def test_signed_value_decoding():
+    """Test decoding signed values from command responses."""
+    signal = create_test_signal(
+        "STEERING_ANGLE",
+        "Steering Angle",
+        {
+            "bit_length": 16,
+            "max_value": 780.0,
+            "min_value": -780.0,
+            "unit": "degrees",
+            "signed": True,
+            "divisor": 10
+        }
+    )
+
+    command = create_test_command(
+        pid=0x3233,
+        service_type=ServiceType.SERVICE_22,
+        receive_address="7E8",
+        signals=[signal]
+    )
+
+    registry = CommandRegistry([command])
+
+    # Test positive angle (45.5 degrees)
+    packet = CANPacket(
+        can_identifier="7E8",
+        extended_receive_address=None,
+        data=bytes.fromhex("623233" + "01C7")  # 455 after scaling
+    )
+
+    responses = registry.identify_commands(packet)
+    assert len(responses) == 1
+    assert pytest.approx(responses[0].values["STEERING_ANGLE"]) == 45.5
+
+    # Test negative angle (-45.5 degrees)
+    packet = CANPacket(
+        can_identifier="7E8",
+        extended_receive_address=None,
+        data=bytes.fromhex("623233" + "FE39")  # -455 after scaling
+    )
+
+    responses = registry.identify_commands(packet)
+    assert len(responses) == 1
+    assert pytest.approx(responses[0].values["STEERING_ANGLE"]) == -45.5
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/python/test_f150.py
+++ b/python/test_f150.py
@@ -1,0 +1,47 @@
+import pytest
+from signals_testing import obd_testrunner
+import json
+import os
+
+REPO_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+TEST_CASES = [
+    # 2021 model year
+    # Target vehicle speed - -61.2 km/h
+    ("76C0562A224FF56", {"F150_CC_TGT_VSS": -61.2}),
+
+    # 2019 model year
+    # Tire pressures
+    ("72E05622813028C", {"F150_TP_FL": 32.6}),
+    ("72E056228140273", {"F150_TP_FR": 31.35}),
+    ("72E056228150291", {"F150_TP_RRO": 32.85}),
+    ("72E05622816026E", {"F150_TP_RLO": 31.1}),
+    ("72E056228170000", {"F150_TP_RRI": 0.0}),
+    ("72E056228180000", {"F150_TP_RLI": 0.0}),
+
+    # 2012 model year
+    # Odometer - 234652.4 km
+    ("7280662404C23CE1C", {"F150_ODO": 234652.4}),
+    # Fuel level - 49.02%
+    ("7E80462F42F7D", {"F150_FLI": 49.01960784313726}),
+    # Steering angle - 555.7 degrees
+    ("76805623201AB6A", {"F150_STEER_ANGLE": 555.6999999999998}),
+    # Transmission oil temp - 68.31 C
+    ("7E805621E1C0445", {"F150_TOT": 68.3125}),
+]
+
+def test_ford_f150_signals():
+    """Test Ford F-150 signal decoding against known responses."""
+    signalset_path = os.path.join(REPO_ROOT, 'testdata', 'ford-f-150.json')
+    with open(signalset_path) as f:
+        signalset_json = f.read()
+
+    # Run each test case
+    for response_hex, expected_values in TEST_CASES:
+        try:
+            obd_testrunner(signalset_json, response_hex, expected_values)
+        except Exception as e:
+            pytest.fail(f"Failed on response {response_hex}: {e}")
+
+if __name__ == '__main__':
+    test_ford_f150_signals()

--- a/python/testdata/ford-f-150.json
+++ b/python/testdata/ford-f-150.json
@@ -1,0 +1,55 @@
+{ "commands": [
+    { "hdr": "720", "rax": "728", "cmd": {"22": "404C"}, "freq": 5,
+      "signals": [
+        {"id": "F150_ODO", "path": "Trips", "fmt": { "len": 24, "max": 1677721, "div": 10, "unit": "kilometers" }, "name": "Odometer (Instrument panel)", "suggestedMetric": "odometer"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2813"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_FL", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front left tire pressure", "suggestedMetric": "frontLeftTirePressure"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2814"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_FR", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Front right tire pressure", "suggestedMetric": "frontRightTirePressure"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2815"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_RRO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right outer tire pressure", "suggestedMetric": "rearRightTirePressure"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2816"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_RLO", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left outer tire pressure", "suggestedMetric": "rearLeftTirePressure"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2817"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_RRI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear right inner tire pressure"}
+      ]},
+    { "hdr": "726", "rax": "72E", "cmd": {"22": "2818"}, "freq": 5,
+      "signals": [
+        {"id": "F150_TP_RLI", "path": "Tires", "fmt": { "len": 16, "max": 3276, "div": 20, "unit": "psi" }, "name": "Rear left inner tire pressure"}
+      ]},
+    { "hdr": "760", "rax": "768", "cmd": {"22": "3201"}, "freq": 0.25,
+      "signals": [
+        {"id": "F150_STEER_ANGLE", "path": "Control", "fmt": { "len": 16, "max": 1638, "min": -1638, "div": 20, "add": -1638.4, "unit": "degrees" }, "name": "Steering wheel angle (ABS)", "description": "Positive is rotated to the left, negative is rotated to the right."}
+      ]},
+    { "hdr": "764", "cmd": {"22": "A224"}, "freq": 0.25,
+      "signals": [
+        {"id": "F150_CC_TGT_VSS", "path": "Cruise control", "fmt": { "len": 16, "max": 736, "min": -736, "mul": 3.6, "div": 10, "sign": true, "unit": "kilometersPerHour" }, "name": "Target vehicle speed", "description": "The speed of the vehicle ahead of you."}
+      ]},
+    { "hdr": "7DF", "cmd": {"22": "1E12"}, "freq": 2,
+      "signals": [
+        {"id": "F150_GEAR", "path": "Engine", "fmt": { "len": 8, "max": 255, "unit": "scalar" }, "name": "Current gear", "description": "The automatic transmission gear. Numbers aren't yet mapped to named gears."}
+      ]},
+    { "hdr": "7DF", "cmd": {"22": "1E1C"}, "freq": 1,
+      "signals": [
+        {"id": "F150_TOT", "path": "Engine", "fmt": { "len": 16, "max": 255, "div": 16, "unit": "celsius" }, "name": "Transmission oil temperature"}
+      ]},
+    { "hdr": "7DF", "cmd": {"22": "1E23"}, "freq": 2,
+      "signals": [
+        {"id": "F150_GEAR_SHFT", "path": "Engine", "fmt": { "len": 8, "max": 255, "unit": "scalar" }, "name": "Shift gear"}
+      ]},
+    { "hdr": "7E0", "rax": "7E8", "cmd": {"22": "F42F"}, "freq": 1,
+      "signals": [
+        {"id": "F150_FLI", "path": "Fuel", "fmt": { "len": 8, "max": 255, "mul": 100, "div": 255, "unit": "percent" }, "name": "Fuel level", "suggestedMetric": "fuelTankLevel"}
+      ]}
+    ]
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=8.3.4
+pytest-cov>=6.0.0


### PR DESCRIPTION
This library is intended to be added as a dependency in any of the OBDb vehicle repositories and used to perform validation tests against the signalset and known data responses for that vehicle. It includes support for:

- Signalset json decoding
- In-memory command/signal representation and decoding
- Service 21 commands
- Service 22 commands
- A standard testing utility to be used by vehicle repos
- An example test on some sample Ford F-150 data.